### PR TITLE
fix type error when no default value for attribute key given

### DIFF
--- a/src/AttributesBag.php
+++ b/src/AttributesBag.php
@@ -44,7 +44,7 @@ class AttributesBag implements ArrayAccess, IteratorAggregate
      * @param mixed $default
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get($key, $default = '')
     {
         return new \Performing\TwigComponents\SlotBag($this->attributes[$key] ?? $default);
     }


### PR DESCRIPTION
Since the argument type of the SlotBag constructor must be a string, a TypeError is thrown when using code in template like `{{ attributes.get('key') }}`