### PR TITLE
Improving fix for arbitrarily-nested components

### DIFF
--- a/src/ComponentNode.php
+++ b/src/ComponentNode.php
@@ -30,7 +30,8 @@ final class ComponentNode extends IncludeNode
 
         $compiler
             ->write(sprintf("if ($%s) {\n", $template))
-            ->write('$oldSlots = $slots ?? [];' . PHP_EOL)
+            ->write('$slotsStack = $slotsStack ?? [];' . PHP_EOL)
+            ->write('$slotsStack[] = $slots ?? [];' . PHP_EOL)
             ->write('$slots = [];' . PHP_EOL)
             ->write("ob_start();"  . PHP_EOL)
             ->subcompile($this->getNode('slot'))
@@ -42,7 +43,7 @@ final class ComponentNode extends IncludeNode
 
         $compiler
             ->raw(");\n")
-            ->write('$slots = $oldSlots;' . PHP_EOL)
+            ->write('$slots = array_pop($slotsStack);' . PHP_EOL)
             ->write("}\n")
         ;
     }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class ComponentTest extends TestCase
 {
+    protected $twig;
+
     protected function setupTwig(): \Twig\Environment
     {
         $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
@@ -20,12 +22,15 @@ class ComponentTest extends TestCase
         return $twig;
     }
 
+    public function setUp(): void
+    {
+        $this->twig = $this->setupTwig();
+    }
+
     /** @test */
     public function render_simple_component()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_simple_component.twig');
+        $html = $this->twig->render('test_simple_component.twig');
 
         $this->assertEquals(<<<HTML
         <button class="bg-blue-600 text-white"> test </button>
@@ -35,9 +40,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_simple_component_with_dash()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_simple_component_with_dash.twig');
+        $html = $this->twig->render('test_simple_component_with_dash.twig');
 
         $this->assertEquals(<<<HTML
         <button class="bg-blue-700 text-white"> test </button>
@@ -47,9 +50,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_simple_component_in_folder()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_simple_component_in_folder.twig');
+        $html = $this->twig->render('test_simple_component_in_folder.twig');
 
         $this->assertEquals(<<<HTML
         <button class="text-white bg-blue-800 rounded"> test </button>
@@ -59,9 +60,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_component_with_slots()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_with_slots.twig');
+        $html = $this->twig->render('test_with_slots.twig');
 
         $this->assertEquals(<<<HTML
         <div><span>test</span><div>test</div></div>
@@ -71,9 +70,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_xtags_with_slots()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_xtags_with_slots.twig');
+        $html = $this->twig->render('test_xtags_with_slots.twig');
 
         $this->assertEquals(<<<HTML
         <div><span>test</span><div>test</div></div>
@@ -83,9 +80,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_nested_xtags_with_slots()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_nested_xtags_with_slots.twig');
+        $html = $this->twig->render('test_nested_xtags_with_slots.twig');
 
         $this->assertEquals(<<<HTML
         <div><span>[outer name]</span><div>[inner name][inner slot]</div></div>
@@ -93,11 +88,20 @@ class ComponentTest extends TestCase
     }
 
     /** @test */
+    public function render_deeply_nested_xtags_with_slots()
+    {
+        $html = $this->twig->render('test_deeply_nested_xtags_with_slots.twig');
+        $html = preg_replace('/\s{2,}/', '', $html); // ignore whitespace difference
+
+        $this->assertEquals(<<<HTML
+        <div><span>A</span><div>BC<div>D<button class="text-white">E</button><div>FG</div></div></div></div>
+        HTML, $html);
+    }
+
+    /** @test */
     public function render_component_with_xtags()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_xtags_component.twig');
+        $html = $this->twig->render('test_xtags_component.twig');
 
         $this->assertEquals(<<<HTML
         <button class="text-white bg-blue-800 rounded"> test1 </button>
@@ -109,9 +113,7 @@ class ComponentTest extends TestCase
     /** @test */
     public function render_component_with_attributes()
     {
-        $twig = $this->setupTwig();
-
-        $html = $twig->render('test_with_attributes.twig');
+        $html = $this->twig->render('test_with_attributes.twig');
 
         $this->assertEquals(<<<HTML
         <div>

--- a/tests/templates/test_deeply_nested_xtags_with_slots.twig
+++ b/tests/templates/test_deeply_nested_xtags_with_slots.twig
@@ -1,0 +1,15 @@
+<x-with-slots>
+    <x-slot name="name"><span>A</span></x-slot>
+    <x-with-slots>
+        <x-slot name="name">B</x-slot>
+        C
+        <x-with-slots>
+            <x-button>E</x-button>
+            <x-slot name="name">D</x-slot>
+            <x-with-slots>
+                <x-slot name="name">F</x-slot>
+                G
+            </x-with-slots>
+        </x-with-slots>
+    </x-with-slots>
+</x-with-slots>


### PR DESCRIPTION
Previous fix only dealt with a single level of nesting. This should cater for deeply-nested components