### PR TITLE
feat: support twig namespaces with `:` in component name

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ components can be included with the following:
 
 <x-ns:button class='bg-blue-600'>
   <span class="text-lg">Click here!</span>
-</x-button>
+</x-ns:button>
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -154,6 +154,29 @@ if (Craft::$app->request->getIsSiteRequest()) {
 }
 ```
 
+### Twig Namespaces
+
+In addition to the specified directory, you can also reference components from a twig namespace by prepending the namespace and a `:` to the component name. With a namespace defined like so:
+
+```php
+// register namespace with twig template loader
+$loader->addPath(__DIR__ . '/some/other/dir', 'ns');
+```
+
+components can be included with the following:
+
+```twig
+{% x:ns:button with {class:'bg-blue-600'} %}
+  <span class="text-lg">Click here!</span>
+{% endx %}
+
+{# or #}
+
+<x-ns:button class='bg-blue-600'>
+  <span class="text-lg">Click here!</span>
+</x-button>
+```
+
 ## Testing
 
 ```bash

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -13,6 +13,8 @@ class ComponentTest extends TestCase
     {
         $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
 
+        $loader->addPath(__DIR__ . '/namespace-templates', 'ns');
+
         $twig = new \Twig\Environment($loader, [
             'cache' => false,
         ]);
@@ -121,6 +123,28 @@ class ComponentTest extends TestCase
          {"foo":1}
          bar
         </div>
+        HTML, $html);
+    }
+
+    /** @test */
+    public function render_namespaced_component()
+    {
+        $html = $this->twig->render('test_namespaced_component.twig');
+
+        $this->assertEquals(<<<HTML
+        <button class="bg-blue-600 ns-button text-white"> test </button>
+        HTML, $html);
+    }
+
+    /** @test */
+    public function render_namespaced_xtags_component()
+    {
+        $html = $this->twig->render('test_namespaced_xtags_component.twig');
+
+        $this->assertEquals(<<<HTML
+        <button class="bg-blue-600 ns-button text-white"> test1 </button>
+        <button class="bg-blue-600 ns-button text-white"> test2 </button>
+        <button class="'bg-blue-600' ns-button text-white"> test3 </button>
         HTML, $html);
     }
 }

--- a/tests/namespace-templates/button.twig
+++ b/tests/namespace-templates/button.twig
@@ -1,0 +1,1 @@
+<button {{ attributes.merge({ class: 'ns-button text-white' }) }}>{{ slot }}</button>

--- a/tests/templates/test_namespaced_component.twig
+++ b/tests/templates/test_namespaced_component.twig
@@ -1,0 +1,1 @@
+{% x:ns:button with {class:'bg-blue-600'} %} test {% endx %}

--- a/tests/templates/test_namespaced_xtags_component.twig
+++ b/tests/templates/test_namespaced_xtags_component.twig
@@ -1,0 +1,5 @@
+<x-ns:button class="{{'bg-blue-' ~ '600' }}"> test1 </x-ns:button>
+
+<x-ns:button :class="'bg-blue-600'"> test2 </x-ns:button>
+
+<x-ns:button class="'bg-blue-600'"> test3 </x-ns:button>


### PR DESCRIPTION
I recently discovered this extension while looking for a 'slots' solution in twig, which this extension does very well. I am working on integrating twig-components into a project that allows plugins to register additional components, so they might not all be stored in one main directory. Initially I tried out initializing the plugin by passing a twig namespace as the component directory, like `@components`, which actually works decently well on its own. I can continue to register additional template directories under that namespace and reference twig files in any of them. This is just a project for my immediate team (for now), but I do see complications if more than one plugin inadvertently adds a twig template with the same filename.

In order to prevent this, I think it would be useful to be able to optionally specify a namespace along with the component name in the opening block tag. When including a component, the component name can contain one `:` which allows a twig namespace to be specified. Example: `{% x:namespace:component.name %}`

```twig
{# includes '@mds/accordion.twig' #}

{% x:mds:accordion with {title: 'Twig Components'} %}
	{% slot:content %}<p>Are Awesome!</p>%{ endslot %}
{% endx %}
{# or #}
<x-mds:accordion title="Twig Components">
	<x-slot name="content"><p>Are Awesome!</p></x-slot>
</x-mds:accordion>
```

I was not too familiar with how twig actually parsed everything, but I did some research and took a look at how the parser in twig-components works and ended up making a couple small additions:

- `parseComponentName` now appends `@` to the initial item in the path if it finds a `:` in the initial component name (before any `.` directory markers)
- I moved the short while loop that looks for dashes into its own function called `getNameSection`.
- `getComponentPath` checks if a namespace is included before appending root directory.

I saw one issue that mentioned namespaces, but it was primarily about subdirectories. I considered trying to use that but to me it makes sense to take advantage of a feature twig has rather than having to nest files in an extra folder level. I made more progress than I originally thought I would, so I figured I would submit it as a PR and start a discussion about how useful others would find this.