### PR TITLE
Add attributes.class('defaultClass') as already documented

### DIFF
--- a/src/View/ComponentAttributeBag.php
+++ b/src/View/ComponentAttributeBag.php
@@ -133,6 +133,11 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate
         return new static($attributes);
     }
 
+    public function class($defaultClass = '')
+    {
+        return $this->merge(['class' => $defaultClass]);
+    }
+
     /**
      * Get all of the raw attributes.
      *


### PR DESCRIPTION
Adds the missing method as used in https://github.com/giorgiopogliani/twig-components#named-slots