### PR TITLE
Fix attributes echo for component in component

### DIFF
--- a/src/Lexer/ComponentTagCompiler.php
+++ b/src/Lexer/ComponentTagCompiler.php
@@ -46,7 +46,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
+                                \{\{\s*attributes(?:.+?)?\s*\}\}
                             )
                             |
                             (?:
@@ -100,7 +100,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
+                                \{\{\s*attributes(?:.+?)?\s*\}\}
                             )
                             |
                             (?:
@@ -169,7 +169,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
+                                \{\{\s*attributes(?:.+?)?\s*\}\}
                             )
                             |
                             (?:
@@ -288,7 +288,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
             (?:^|\s+)                                        # start of the string or whitespace between attributes
-            \{\{\s*(\\\$attributes(?:[^}]+?(?<!\s))?)\s*\}\} # exact match of attributes variable being echoed
+            \{\{\s*(attributes(?:.+?(?<!\s))?)\s*\}\} # exact match of attributes variable being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);


### PR DESCRIPTION
button.twig:
```
<button {{ attributes.merge({ class: 'defaultClass' }) }}>{{ slot }}</button>
```

button/red.twig:
```
<x-button {{ attributes.merge({ class: 'bg-red-500' }) }}>{{ slot }}</x-button>
```

With the templates above the usage of `<x-button.red class="mb-5">Click me</x-button.red>` would fail. Some changes to the regex in `ComponentTagCompiler` fixes that.
