### PR TITLE
Fix compatibility issue with PHP 8.2 array access function signature.

### DIFF
--- a/src/View/ComponentAttributeBag.php
+++ b/src/View/ComponentAttributeBag.php
@@ -191,7 +191,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate
      * @param string $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->get($offset);
     }


### PR DESCRIPTION
This is an amazing addition to Twig bringing the greatness of Blade style components! Thanks so much. Here's just a quick fix to add a missing signature for arrayAccess on the component attribute bag.