### PR TITLE
Add support for OctoberCMS / WinterCMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ plugins
             $twig = $controller->getTwig();
 
             Configuration::make($twig)
-                ->setNeedsHintPath(true)
-                ->setTemplatesPath('namespace.pluginname::components')
+                ->setTemplatesPath('namespace.pluginname::components', hint: true)
                 ->useCustomTags()
                 ->setup();
         });

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ final class TwigEnvironmentConfigurator
 
 ### OctoberCMS / WinterCMS
 
-In OctoberCMS / WinterCMS you need to hook into ```cms.page.beforedisplay``` event in order to access twig instance.
+In OctoberCMS / WinterCMS you need to hook into ```cms.page.beforedisplay``` event inside your plugin's boot method in order to access twig instance.
 Then you can use your plugin hint path to choose a views subfolder as component's folder.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -97,7 +97,42 @@ final class TwigEnvironmentConfigurator
 }
 ```
 
+### OctoberCMS / WinterCMS
+
+In OctoberCMS / WinterCMS you need to hook into ```cms.page.beforedisplay``` event in order to access twig instance.
+Then you can use your plugin hint path to choose a views subfolder as component's folder.
+
 ## Usage
+es. 
+```
+plugins
+|__namespace
+   |__pluginname
+      |__views
+         |__components
+            |__button.htm
+```
+
+```php
+Event::Listen('cms.page.beforeDisplay', function ($controller, $url, $page) {
+    $twig = $controller->getTwig();
+
+    Configuration::make($twig)
+        ->setNeedsHintPath(true)
+        ->setTemplatesPath('namespace.pluginname::components')
+        ->useCustomTags()
+        ->setup();
+});
+```
+
+then in your htm files
+
+```
+<x-button>...</x-button>
+```
+
+Alle features like subfolders are supported, like ```<x-forms.input></x-forms.input>``` will refer to ```plugins/namespace/pluginname/views/forms/input.htm```
+
 
 The components are just Twig templates in a folder of your choice (e.g. `components`) and can be used anywhere in your Twig templates. The slot variable is any content you will add between the opening and the close tag.
 

--- a/README.md
+++ b/README.md
@@ -114,15 +114,18 @@ plugins
 ```
 
 ```php
-Event::Listen('cms.page.beforeDisplay', function ($controller, $url, $page) {
-    $twig = $controller->getTwig();
+ public function boot(): void
+    {
+        Event::Listen('cms.page.beforeDisplay', function ($controller, $url, $page) {
+            $twig = $controller->getTwig();
 
-    Configuration::make($twig)
-        ->setNeedsHintPath(true)
-        ->setTemplatesPath('namespace.pluginname::components')
-        ->useCustomTags()
-        ->setup();
-});
+            Configuration::make($twig)
+                ->setNeedsHintPath(true)
+                ->setTemplatesPath('namespace.pluginname::components')
+                ->useCustomTags()
+                ->setup();
+        });
+    }
 ```
 
 then in your htm files

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -45,9 +45,7 @@ class Configuration
     public function setTemplatesPath(string $path, bool $hint = false): self
     {
         $this->templatesPath = rtrim($path, DIRECTORY_SEPARATOR);
-        if ($hint) {
-            $this->needsHintPath = true;
-        }
+        $this->needsHintPath = $hint;
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -36,22 +36,18 @@ class Configuration
         return new static($twig);
     }
 
-    public function setNeedsHintPath(bool $needsHintPath): self
-    {
-        $this->needsHintPath = $needsHintPath;
-
-        return $this;
-    }
-
     /**
      * Set relative path to components templates.
      *
      * @param string $path
      * @return Configuration
      */
-    public function setTemplatesPath(string $path): self
+    public function setTemplatesPath(string $path, bool $hint = false): self
     {
         $this->templatesPath = rtrim($path, DIRECTORY_SEPARATOR);
+        if ($hint) {
+            $this->needsHintPath = true;
+        }
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -18,6 +18,8 @@ class Configuration
 
     protected string $templatesPath = 'components';
 
+    protected bool $needsHintPath = false;
+
     protected bool $isUsingTemplatesExtension = true;
 
     protected string $templatesExtension = 'twig';
@@ -32,6 +34,13 @@ class Configuration
     public static function make(Environment $twig): Configuration
     {
         return new static($twig);
+    }
+
+    public function setNeedsHintPath(bool $needsHintPath): self
+    {
+        $this->needsHintPath = $needsHintPath;
+
+        return $this;
     }
 
     /**
@@ -50,6 +59,11 @@ class Configuration
     public function getTemplatesPath(): string
     {
         return $this->templatesPath;
+    }
+
+    public function getNeedsHintPath(): bool
+    {
+        return $this->needsHintPath;
     }
 
     public function useTemplatesExtension(bool $isUsing = true): self

--- a/src/TokenParser/ComponentTokenParser.php
+++ b/src/TokenParser/ComponentTokenParser.php
@@ -31,8 +31,13 @@ final class ComponentTokenParser extends IncludeTokenParser
 
         $componentPath = rtrim($this->configuration->getTemplatesPath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $name;
 
-        if ($this->configuration->isUsingTemplatesExtension()) {
-            $componentPath .= '.' . $this->configuration->getTemplatesExtension();
+        if ($this->configuration->getNeedsHintPath()) {
+            $componentPath = rtrim($componentPath, '.');
+            $componentPath = str_replace('/', '.', $componentPath);
+        } else {
+            if ($this->configuration->isUsingTemplatesExtension()) {
+                $componentPath .= '.' . $this->configuration->getTemplatesExtension();
+            }
         }
 
         return  $componentPath;

--- a/src/TokenParser/ComponentTokenParser.php
+++ b/src/TokenParser/ComponentTokenParser.php
@@ -45,7 +45,7 @@ final class ComponentTokenParser extends IncludeTokenParser
 
     public function parse(Token $token): Node
     {
-        list($variables, $name) = $this->parseArguments();
+        [$variables, $name] = $this->parseArguments();
 
         $slot = $this->parser->subparse([$this, 'decideBlockEnd'], true);
 

--- a/tests/ComponentTokenParserTest.php
+++ b/tests/ComponentTokenParserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Performing\TwigComponents\Tests;
+
+use Performing\TwigComponents\Configuration;
+use Performing\TwigComponents\TokenParser\ComponentTokenParser;
+use PHPUnit\Framework\TestCase;
+
+
+class ComponentTokenParserTest extends TestCase
+{
+    private Configuration $configuration;
+
+    public function setUp(): void
+    {
+        $this->configuration = $this->createMock(Configuration::class);
+    }
+
+    public function testGetComponentPathWithHintPath()
+    {
+        $this->configuration->method('getNeedsHintPath')
+            ->willReturn(true);
+
+        $this->configuration->method('getTemplatesPath')
+            ->willReturn('mynamespace.myplugin::components');
+
+        $this->configuration->method('getTemplatesExtension')
+            ->willReturn('twig');
+
+        $parser = new ComponentTokenParser($this->configuration);
+
+        $componentPath = $parser->getComponentPath('test/component');
+
+        $this->assertEquals('mynamespace.myplugin::components.test.component', $componentPath);
+    }
+
+    public function testGetComponentPathWithoutHintPath()
+    {
+        $this->configuration->method('getNeedsHintPath')
+            ->willReturn(false);
+
+        $this->configuration->method('getTemplatesPath')
+            ->willReturn('mynamespace.myplugin::components');
+
+        $this->configuration->method('getTemplatesExtension')
+            ->willReturn('twig');
+
+        $parser = new ComponentTokenParser($this->configuration);
+
+        $componentPath = $parser->getComponentPath('test/component');
+
+        $this->assertNotEquals('mynamespace.myplugin::components.test.component', $componentPath);
+    }
+}

--- a/tests/ComponentTokenParserTest.php
+++ b/tests/ComponentTokenParserTest.php
@@ -6,49 +6,45 @@ use Performing\TwigComponents\Configuration;
 use Performing\TwigComponents\TokenParser\ComponentTokenParser;
 use PHPUnit\Framework\TestCase;
 
-
 class ComponentTokenParserTest extends TestCase
 {
-    private Configuration $configuration;
-
-    public function setUp(): void
-    {
-        $this->configuration = $this->createMock(Configuration::class);
-    }
-
     public function testGetComponentPathWithHintPath()
     {
-        $this->configuration->method('getNeedsHintPath')
-            ->willReturn(true);
+        $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
+        $twig = new \Twig\Environment($loader);
 
-        $this->configuration->method('getTemplatesPath')
-            ->willReturn('mynamespace.myplugin::components');
+        $config = Configuration::make($twig)
+            ->setTemplatesPath('mynamespace.myplugin::components', hint: true)
+            ->setTemplatesExtension('twig')
+            ->useCustomTags();
 
-        $this->configuration->method('getTemplatesExtension')
-            ->willReturn('twig');
+        $this->assertTrue($config->getNeedsHintPath());
+        $this->assertEquals($config->getTemplatesPath(), 'mynamespace.myplugin::components');
+        $this->assertEquals($config->getTemplatesExtension(), 'twig');
 
-        $parser = new ComponentTokenParser($this->configuration);
-
+        $parser = new ComponentTokenParser($config);
         $componentPath = $parser->getComponentPath('test/component');
-
         $this->assertEquals('mynamespace.myplugin::components.test.component', $componentPath);
     }
 
     public function testGetComponentPathWithoutHintPath()
     {
-        $this->configuration->method('getNeedsHintPath')
-            ->willReturn(false);
+        $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/templates');
+        $twig = new \Twig\Environment($loader);
 
-        $this->configuration->method('getTemplatesPath')
-            ->willReturn('mynamespace.myplugin::components');
+        $config = Configuration::make($twig)
+            ->setTemplatesPath('_components', hint: false)
+            ->setTemplatesExtension('twig')
+            ->useCustomTags();
 
-        $this->configuration->method('getTemplatesExtension')
-            ->willReturn('twig');
+        $this->assertFalse($config->getNeedsHintPath());
+        $this->assertEquals($config->getTemplatesPath(), '_components');
+        $this->assertEquals($config->getTemplatesExtension(), 'twig');
 
-        $parser = new ComponentTokenParser($this->configuration);
+        $parser = new ComponentTokenParser($config);
 
         $componentPath = $parser->getComponentPath('test/component');
 
-        $this->assertNotEquals('mynamespace.myplugin::components.test.component', $componentPath);
+        $this->assertEquals('_components/test/component.twig', $componentPath);
     }
 }


### PR DESCRIPTION
Hello there, thank you for your great work. In order to use this extension with OctoberCMS / WinterCMS, I need to update how the component path is generated. This CMS load twig always with .htm extension and using a hint path style.

Es.
```
mynamespace
|__ myplugin
    |__views
        |__ components
             |__ button.htm
```

can be references as "mynamespace.myplugin::components.button". Not using this syntax cause the CMS's custom twig loader to fail. With this PR I add a basicu support for using hint paths, using this syntax:

```php
 Configuration::make($twig)
                ->setNeedsHintPath(true)
                ->setTemplatesPath('mynamespace.myplugin::components')
                ->useCustomTags()
                ->setup();
```

Let me know if you like the idea and if you want to change something! Cheers!